### PR TITLE
String manipulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ doc/api/
 test/.test_coverage.dart
 coverage
 coverage_badge.svg
+
+
+# Android Studi
+.idea/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It also assumes that your project follows [Semantic Versioning v2.0.0](https://s
 ```
 pub global activate cider
 ```
+
 ## Configure
 The config file name is `.cider.yaml`. It should reside in the root folder of the project. This file is optional. 
 So far it consists of just a single entry.
@@ -38,6 +39,7 @@ cider log change 'New turbo engine installed'
 cider log add 'Support for rocket fuel and kerosene'
 cider log fix 'No more wheels falling off'
 ```
+
 ## Releasing the unreleased changes
 This command takes all changes from the `Unreleased` section on the changelog and creates a new release with the
 version from pubspec.yaml
@@ -50,8 +52,10 @@ Use `--date` to provide the release date (the default is today).
 
 Cider will automatically generate the diff links in the changelog if the diff link template is found in the config.
 
+
 ## Setting the project version
 ```
+cider set <new_version>
 cider version <new_version>
 ```
 - **new_version** must be semver-compatible
@@ -60,6 +64,11 @@ Version before | Command | Version after
 --- | --- | ---
 1.2.3 | `cider set 3.2.1`  | 3.2.1
 0.2.1 | `cider set 0.0.1-dev`  | 0.0.1-dev
+--- | --- | ---
+1.2.3 | `cider version 3.2.1`  | 3.2.1
+0.2.1 | `cider version test/0.0.1-dev`  | 0.0.1
+
+
 
 ## Bumping the project version
 ```
@@ -96,19 +105,6 @@ Version before | Command | Version after
 0.2.1+42 | `cider bump breaking -b`    | 0.3.0+42
 0.2.1+42 | `cider bump patch`          | 0.2.2
 0.2.1+42 | `cider bump patch -b`       | 0.2.2+42
-
-
-## Setting the version explicitly
-```
-cider version <new_version>
-```
-- **new_version** is any arbitrary version
-
-Examples
-```
-cider version 3.0.0
-cider version 1.2.0-nullsafety+42
-```
 
 ## Printing the current project version
 ```

--- a/lib/src/console/command/version_command.dart
+++ b/lib/src/console/command/version_command.dart
@@ -26,7 +26,7 @@ class VersionCommand extends ApplicationCommand {
 
   int _setVersion(String version) {
     try {
-      String aStr = version.replaceAll(new RegExp(r'[^0-9.]'),'');
+      String aStr = version.replaceAll(RegExp(r'[^0-9.]'),'');
       createApp().setVersion(aStr);
     } on FormatException {
       _console.error('Invalid version "$version".');

--- a/lib/src/console/command/version_command.dart
+++ b/lib/src/console/command/version_command.dart
@@ -26,7 +26,8 @@ class VersionCommand extends ApplicationCommand {
 
   int _setVersion(String version) {
     try {
-      createApp().setVersion(version);
+      String aStr = version.replaceAll(new RegExp(r'[^0-9.]'),'');
+      createApp().setVersion(aStr);
     } on FormatException {
       _console.error('Invalid version "$version".');
       return ExitCode.applicationError;

--- a/lib/src/console/command/version_command.dart
+++ b/lib/src/console/command/version_command.dart
@@ -26,7 +26,7 @@ class VersionCommand extends ApplicationCommand {
 
   int _setVersion(String version) {
     try {
-      var aStr = version.replaceAll(RegExp(r'[^0-9.]'),'');
+      var aStr = version.replaceAll(RegExp(r'[^0-9.]'), '');
       createApp().setVersion(aStr);
     } on FormatException {
       _console.error('Invalid version "$version".');

--- a/lib/src/console/command/version_command.dart
+++ b/lib/src/console/command/version_command.dart
@@ -26,7 +26,7 @@ class VersionCommand extends ApplicationCommand {
 
   int _setVersion(String version) {
     try {
-      String aStr = version.replaceAll(RegExp(r'[^0-9.]'),'');
+      var aStr = version.replaceAll(RegExp(r'[^0-9.]'),'');
       createApp().setVersion(aStr);
     } on FormatException {
       _console.error('Invalid version "$version".');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,16 +7,16 @@ issue_tracker: https://github.com/f3ath/cider/issues
 
 dependencies:
   args: ^1.6.0
-  change: ^0.1.1
+  change: ^0.1.0
   intl: ^0.16.1
   markdown: ^2.1.5
-  marker: ^0.1.1
-  maybe_just_nothing: ^0.3.1
+  marker: ^0.1.0
+  maybe_just_nothing: ^0.3.0
   path: ^1.6.0
   pub_semver: ^1.4.4
   version_manipulation: ^0.0.4
   yaml: ^2.2.1
-  yaml_edit: ^1.0.3
+  yaml_edit: ^1.0.0
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cider
-version: 0.0.5
+version: 0.1.0
 description: Tools for Dart package maintainers. Automates CHANGLELOG and pubspec.yaml updates.
 homepage: https://github.com/f3ath/cider
 repository: https://github.com/f3ath/cider/tree/master
@@ -7,16 +7,16 @@ issue_tracker: https://github.com/f3ath/cider/issues
 
 dependencies:
   args: ^1.6.0
-  change: ^0.1.0
+  change: ^0.1.1
   intl: ^0.16.1
   markdown: ^2.1.5
-  marker: ^0.1.0
-  maybe_just_nothing: ^0.3.0
+  marker: ^0.1.1
+  maybe_just_nothing: ^0.3.1
   path: ^1.6.0
   pub_semver: ^1.4.4
   version_manipulation: ^0.0.4
   yaml: ^2.2.1
-  yaml_edit: ^1.0.0
+  yaml_edit: ^1.0.3
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -118,11 +118,11 @@ void main() {
     test('Set successfully', () async {
       await File('test/samples/pubspec-1.1.0.yaml').copy(pubspecPath);
       expect(
-          await app.run(['--project-root', temp.path, 'version', '1.2.3']), 0);
+          await app.run(['--project-root', temp.path, 'version', '1.2.3-beta']),
+          0);
       expect(console.logs.single, '1.2.3-beta');
-
       expect(await app.run(['version', '--project-root', temp.path]), 0);
-      expect(console.logs[1], '1.2.3');
+      expect(console.logs[1], '1.2.3-beta');
     });
     test('Set errors out', () async {
       await File('test/samples/pubspec-1.1.0.yaml').copy(pubspecPath);

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -118,11 +118,11 @@ void main() {
     test('Set successfully', () async {
       await File('test/samples/pubspec-1.1.0.yaml').copy(pubspecPath);
       expect(
-          await app.run(['--project-root', temp.path, 'version', '1.2.3-beta']),
-          0);
+          await app.run(['--project-root', temp.path, 'version', '1.2.3']), 0);
       expect(console.logs.single, '1.2.3-beta');
+
       expect(await app.run(['version', '--project-root', temp.path]), 0);
-      expect(console.logs[1], '1.2.3-beta');
+      expect(console.logs[1], '1.2.3');
     });
     test('Set errors out', () async {
       await File('test/samples/pubspec-1.1.0.yaml').copy(pubspecPath);

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -122,7 +122,7 @@ void main() {
           0);
       expect(console.logs.single, '1.2.3-beta');
       expect(await app.run(['version', '--project-root', temp.path]), 0);
-      expect(console.logs[1], '1.2.3-beta');
+      expect(console.logs[1], '1.2.3');
     });
     test('Set errors out', () async {
       await File('test/samples/pubspec-1.1.0.yaml').copy(pubspecPath);


### PR DESCRIPTION
There are currently two set methods and I've modified one of them.

`Set` has remained as it was before, it changes the version of everything that is specified.

`Version` however extracts the numbers and the points from the given string.

This is especially useful if you run the plugin from a Github workflow and want to use the branch name as the version.
Say the branchname is: `release / 0.1.8`
then the version is only `0.1.8`