### PR TITLE
Fix: abort root folder search upon reaching filesystem root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Correctly abort upwards search for project root directory upon reaching filesystem root.
+
 ## [0.1.5] - 2023-03-30
 ### Added
 - Ability to yank/unyank specific versions
@@ -78,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial version
 
+[Unreleased]: https://github.com/f3ath/cider/compare/0.1.5...HEAD
 [0.1.5]: https://github.com/f3ath/cider/compare/0.1.4...0.1.5
 [0.1.4]: https://github.com/f3ath/cider/compare/0.1.3...0.1.4
 [0.1.3]: https://github.com/f3ath/cider/compare/0.1.2...0.1.3

--- a/lib/src/cider.dart
+++ b/lib/src/cider.dart
@@ -31,7 +31,9 @@ class Cider {
   /// Throws a [StateError] if 'pubspec.yaml' can not be located.
   static io.Directory _findRoot(io.Directory dir) {
     if (io.File(join(dir.path, 'pubspec.yaml')).existsSync()) return dir;
-    if (dir == dir.parent) throw StateError('Can not find project root');
+    if (io.FileSystemEntity.identicalSync(dir.path, dir.parent.path)) {
+      throw StateError('Can not find project root');
+    }
     return _findRoot(dir.parent);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cider
-version: 0.1.5
+version: 0.1.6
 description: Tools for Dart package maintainers. Automates changelog and pubspec.yaml updates.
 homepage: https://github.com/f3ath/cider
 repository: https://github.com/f3ath/cider


### PR DESCRIPTION
On Linux I experienced the findroot function looping for ever and not aborting upon reaching the filesystem root.
The following patch is an attempt to fix this.