### PR TITLE
Fix: Test setup does not await file copying

### DIFF
--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -20,11 +20,11 @@ void main() {
     out.buffer.clear();
     err.buffer.clear();
     temp = await Directory.systemTemp.createTemp();
-    await Directory('test/template').list().forEach((element) async {
+    await for (final element in Directory('test/template').list()) {
       if (element is File) {
         await element.copy(path.join(temp.path, path.basename(element.path)));
       }
-    });
+    }
   });
 
   tearDown(() async {


### PR DESCRIPTION
I started to look into the code of this project, and the tests failed randomly. Copying files from the template dir into the temporary dir is not awaited correctly.

Sometimes, the file copying is not fast enough, and the CLI fails because it cannot find or read the content of the "copied" `pubspec.yaml`.

For some reference on how `forEach` works on a `Stream,` click [here](https://api.dart.dev/stable/3.2.4/dart-async/Stream/forEach.html). The new code uses a `for` loop, which awaits the processing of the stream elements.