### PR TITLE
refactor: rename 'printer' variable to 'console'

### DIFF
--- a/lib/src/cli/command/bump_command.dart
+++ b/lib/src/cli/command/bump_command.dart
@@ -20,10 +20,10 @@ enum BumpType {
 }
 
 class BumpCommand extends CiderCommand {
-  BumpCommand(super.printer) {
+  BumpCommand(super.console) {
     for (final type in BumpType.values) {
       addSubcommand(
-        BumpSubCommand(type.name, type.description, type.mutation, printer),
+        BumpSubCommand(type.name, type.description, type.mutation, console),
       );
     }
   }

--- a/lib/src/cli/command/bump_sub_command.dart
+++ b/lib/src/cli/command/bump_sub_command.dart
@@ -4,8 +4,8 @@ import 'package:cider/src/cli/command/cider_command.dart';
 import 'package:version_manipulation/mutations.dart';
 
 class BumpSubCommand extends CiderCommand {
-  BumpSubCommand(this.name, this.description, this.mutation, Console printer)
-      : super(printer) {
+  BumpSubCommand(this.name, this.description, this.mutation, Console console)
+      : super(console) {
     argParser
       ..addFlag('keep-build', help: 'Keep the existing build')
       ..addFlag('bump-build', help: 'Also bump the build')
@@ -30,7 +30,7 @@ class BumpSubCommand extends CiderCommand {
         bumpBuild: argResults!['bump-build'],
         build: argResults!['build'],
         pre: argResults!['pre']);
-    printer.out.writeln(result);
+    console.out.writeln(result);
 
     return 0;
   }

--- a/lib/src/cli/command/cider_command.dart
+++ b/lib/src/cli/command/cider_command.dart
@@ -10,9 +10,9 @@ import 'package:rfc_6901/rfc_6901.dart';
 import 'package:yaml/yaml.dart';
 
 abstract class CiderCommand extends Command<int> {
-  CiderCommand(this.printer);
+  CiderCommand(this.console);
 
-  final Console printer;
+  final Console console;
 
   Future<int> exec(Project project);
 
@@ -41,7 +41,7 @@ abstract class CiderCommand extends Command<int> {
   }
 
   @override
-  printUsage() => printer.out.writeln(usage);
+  printUsage() => console.out.writeln(usage);
 }
 
 extension _Map on Map {

--- a/lib/src/cli/command/describe_command.dart
+++ b/lib/src/cli/command/describe_command.dart
@@ -2,7 +2,7 @@ import 'package:cider/src/project.dart';
 import 'package:cider/src/cli/command/cider_command.dart';
 
 class DescribeCommand extends CiderCommand {
-  DescribeCommand(super.printer) {
+  DescribeCommand(super.console) {
     argParser.addFlag(onlyBody,
         abbr: 'b',
         help: 'Print only the section body (no header, no link).',
@@ -20,7 +20,7 @@ class DescribeCommand extends CiderCommand {
   @override
   Future<int> exec(Project project) async {
     final version = argResults!.rest.isEmpty ? null : argResults!.rest.first;
-    printer.out.writeln(
+    console.out.writeln(
         await project.describe(version, onlyBody: argResults![onlyBody]));
     return 0;
   }

--- a/lib/src/cli/command/list_command.dart
+++ b/lib/src/cli/command/list_command.dart
@@ -2,7 +2,7 @@ import 'package:cider/src/project.dart';
 import 'package:cider/src/cli/command/cider_command.dart';
 
 class ListCommand extends CiderCommand {
-  ListCommand(super.printer) {
+  ListCommand(super.console) {
     argParser.addFlag(includeYanked,
         abbr: 'y',
         help: 'Include yanked versions',
@@ -29,7 +29,7 @@ class ListCommand extends CiderCommand {
     (await project.getAllVersions(
             includeYanked: argResults![includeYanked],
             includeUnreleased: argResults![includeUnreleased]))
-        .forEach(printer.out.writeln);
+        .forEach(console.out.writeln);
     return 0;
   }
 }

--- a/lib/src/cli/command/log_command.dart
+++ b/lib/src/cli/command/log_command.dart
@@ -17,10 +17,10 @@ enum LogType {
 }
 
 class LogCommand extends CiderCommand {
-  LogCommand(super.printer) {
+  LogCommand(super.console) {
     for (final type in LogType.values) {
       addSubcommand(
-        LogSubCommand(type.name, type.description, type, printer),
+        LogSubCommand(type.name, type.description, type, console),
       );
     }
   }

--- a/lib/src/cli/command/log_sub_command.dart
+++ b/lib/src/cli/command/log_sub_command.dart
@@ -4,8 +4,8 @@ import 'package:cider/src/project.dart';
 import 'package:cider/src/cli/command/cider_command.dart';
 
 class LogSubCommand extends CiderCommand {
-  LogSubCommand(this.name, this.description, this.type, Console printer)
-      : super(printer);
+  LogSubCommand(this.name, this.description, this.type, Console console)
+      : super(console);
 
   @override
   final String name;

--- a/lib/src/cli/command/preamble_command.dart
+++ b/lib/src/cli/command/preamble_command.dart
@@ -2,7 +2,7 @@ import 'package:cider/src/cli/command/cider_command.dart';
 import 'package:cider/src/project.dart';
 
 class PreambleCommand extends CiderCommand {
-  PreambleCommand(super.printer);
+  PreambleCommand(super.console);
 
   @override
   final name = 'preamble';

--- a/lib/src/cli/command/release_command.dart
+++ b/lib/src/cli/command/release_command.dart
@@ -2,7 +2,7 @@ import 'package:cider/src/project.dart';
 import 'package:cider/src/cli/command/cider_command.dart';
 
 class ReleaseCommand extends CiderCommand {
-  ReleaseCommand(super.printer) {
+  ReleaseCommand(super.console) {
     argParser.addOption('date', help: 'Release date', defaultsTo: 'today');
   }
 
@@ -16,7 +16,7 @@ class ReleaseCommand extends CiderCommand {
     final date = argResults!['date'];
     final parsedDate = date == 'today' ? DateTime.now() : DateTime.parse(date);
     final release = await project.release(parsedDate);
-    printer.out.writeln(release);
+    console.out.writeln(release);
     return 0;
   }
 }

--- a/lib/src/cli/command/unyank_command.dart
+++ b/lib/src/cli/command/unyank_command.dart
@@ -2,7 +2,7 @@ import 'package:cider/src/project.dart';
 import 'package:cider/src/cli/command/cider_command.dart';
 
 class UnyankCommand extends CiderCommand {
-  UnyankCommand(super.printer);
+  UnyankCommand(super.console);
 
   @override
   final name = 'unyank';
@@ -13,7 +13,7 @@ class UnyankCommand extends CiderCommand {
   Future<int> exec(Project project) async {
     final version = argResults!.rest.first;
     final release = await project.setYanked(version, false);
-    printer.out.writeln(release);
+    console.out.writeln(release);
     return 0;
   }
 }

--- a/lib/src/cli/command/version_command.dart
+++ b/lib/src/cli/command/version_command.dart
@@ -3,7 +3,7 @@ import 'package:cider/src/project.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 class VersionCommand extends CiderCommand {
-  VersionCommand(super.printer);
+  VersionCommand(super.console);
 
   @override
   final name = 'version';
@@ -16,7 +16,7 @@ class VersionCommand extends CiderCommand {
       final version = Version.parse(argResults!.rest.first);
       await project.setVersion(version);
     }
-    printer.out.writeln(await project.getVersion());
+    console.out.writeln(await project.getVersion());
     return 0;
   }
 }

--- a/lib/src/cli/command/yank_command.dart
+++ b/lib/src/cli/command/yank_command.dart
@@ -2,7 +2,7 @@ import 'package:cider/src/project.dart';
 import 'package:cider/src/cli/command/cider_command.dart';
 
 class YankCommand extends CiderCommand {
-  YankCommand(super.printer);
+  YankCommand(super.console);
 
   @override
   final name = 'yank';
@@ -13,7 +13,7 @@ class YankCommand extends CiderCommand {
   Future<int> exec(Project project) async {
     final version = argResults!.rest.first;
     final release = await project.setYanked(version, true);
-    printer.out.writeln(release);
+    console.out.writeln(release);
     return 0;
   }
 }

--- a/lib/src/cli/error_interceptor.dart
+++ b/lib/src/cli/error_interceptor.dart
@@ -2,9 +2,9 @@ import 'package:args/command_runner.dart';
 import 'package:cider/src/cli/console.dart';
 
 class ErrorInterceptor {
-  ErrorInterceptor(this.printer);
+  ErrorInterceptor(this.console);
 
-  final Console printer;
+  final Console console;
 
   /// POSIX exit codes from sysexits.h
   static const exitOK = 0;
@@ -16,13 +16,13 @@ class ErrorInterceptor {
     try {
       return await f() ?? exitOK;
     } on UsageException catch (e) {
-      printer.err.writeln(e.usage);
+      console.err.writeln(e.usage);
       return exitUsageError;
     } on ArgumentError catch (e) {
-      printer.err.writeln(e.message);
+      console.err.writeln(e.message);
       return exitDataError;
     } catch (e) {
-      printer.err.writeln(e);
+      console.err.writeln(e);
       return exitSoftwareError;
     }
   }

--- a/test/error_interceptor_test.dart
+++ b/test/error_interceptor_test.dart
@@ -6,8 +6,8 @@ import 'package:test/test.dart';
 void main() {
   final out = BufferChannel();
   final err = BufferChannel();
-  final printer = Console(out: out, err: err);
-  final interceptor = ErrorInterceptor(printer);
+  final console = Console(out: out, err: err);
+  final interceptor = ErrorInterceptor(console);
 
   test('default handler prints to stderr and returns 70', () async {
     final code = await interceptor.run(() => throw 'Foo');


### PR DESCRIPTION
### Issue

As already mentioned by @f3ath [here](https://github.com/f3ath/cider/pull/70#discussion_r1472168552).
It's not really a problem, but the variable that is holding the `Console` instance is named `printer`.

### Resolution

- [x] rename `printer` to `console` in the whole project.