### PR TITLE
Support custom tag naming

### DIFF
--- a/lib/src/cli/command/cider_command.dart
+++ b/lib/src/cli/command/cider_command.dart
@@ -32,16 +32,16 @@ abstract class CiderCommand extends Command<int> {
         config.read<String>('/link_template/diff', orElse: () => '');
     final tagTemplate =
         config.read<String>('/link_template/tag', orElse: () => '');
-    final templateTagPrefix =
-        config.read<String>('/link_template/tag_prefix', orElse: () => '');
+    final versionTemplate =
+        config.read<String>('/link_template/version', orElse: () => '');
     final keepEmptyUnreleased =
         config.read<bool>('/keep_empty_unreleased', orElse: () => false);
 
     return Config(
       diffTemplate: diffTemplate,
       tagTemplate: tagTemplate,
+      versionTemplate: versionTemplate,
       keepEmptyUnreleased: keepEmptyUnreleased,
-      templateTagPrefix: templateTagPrefix,
     );
   }
 

--- a/lib/src/cli/command/cider_command.dart
+++ b/lib/src/cli/command/cider_command.dart
@@ -34,10 +34,14 @@ abstract class CiderCommand extends Command<int> {
         config.read<String>('/link_template/tag', orElse: () => '');
     final keepEmptyUnreleased =
         config.read<bool>('/keep_empty_unreleased', orElse: () => false);
+    final tagPrefix = config.read<String>('/tag_prefix', orElse: () => '');
+
     return Config(
-        diffTemplate: diffTemplate,
-        tagTemplate: tagTemplate,
-        keepEmptyUnreleased: keepEmptyUnreleased);
+      diffTemplate: diffTemplate,
+      tagTemplate: tagTemplate,
+      keepEmptyUnreleased: keepEmptyUnreleased,
+      tagPrefix: tagPrefix,
+    );
   }
 
   @override

--- a/lib/src/cli/command/cider_command.dart
+++ b/lib/src/cli/command/cider_command.dart
@@ -32,15 +32,16 @@ abstract class CiderCommand extends Command<int> {
         config.read<String>('/link_template/diff', orElse: () => '');
     final tagTemplate =
         config.read<String>('/link_template/tag', orElse: () => '');
+    final templateTagPrefix =
+        config.read<String>('/link_template/tag_prefix', orElse: () => '');
     final keepEmptyUnreleased =
         config.read<bool>('/keep_empty_unreleased', orElse: () => false);
-    final tagPrefix = config.read<String>('/tag_prefix', orElse: () => '');
 
     return Config(
       diffTemplate: diffTemplate,
       tagTemplate: tagTemplate,
       keepEmptyUnreleased: keepEmptyUnreleased,
-      tagPrefix: tagPrefix,
+      templateTagPrefix: templateTagPrefix,
     );
   }
 

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -5,7 +5,7 @@ class Config {
   Config(
       {String diffTemplate = '',
       String tagTemplate = '',
-      this.tagPrefix = '',
+      this.templateTagPrefix = '',
       this.keepEmptyUnreleased = false,
       this.changelogNewline = true})
       : diffTemplate = Diff(diffTemplate),
@@ -15,5 +15,5 @@ class Config {
   final Tag tagTemplate;
   final bool keepEmptyUnreleased;
   final bool changelogNewline;
-  final String tagPrefix;
+  final String templateTagPrefix;
 }

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -5,6 +5,7 @@ class Config {
   Config(
       {String diffTemplate = '',
       String tagTemplate = '',
+      this.tagPrefix = '',
       this.keepEmptyUnreleased = false,
       this.changelogNewline = true})
       : diffTemplate = Diff(diffTemplate),
@@ -14,4 +15,5 @@ class Config {
   final Tag tagTemplate;
   final bool keepEmptyUnreleased;
   final bool changelogNewline;
+  final String tagPrefix;
 }

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -1,19 +1,21 @@
 import 'package:cider/src/template/diff.dart';
 import 'package:cider/src/template/tag.dart';
+import 'package:cider/src/template/version.dart';
 
 class Config {
-  Config(
-      {String diffTemplate = '',
-      String tagTemplate = '',
-      this.templateTagPrefix = '',
-      this.keepEmptyUnreleased = false,
-      this.changelogNewline = true})
-      : diffTemplate = Diff(diffTemplate),
-        tagTemplate = Tag(tagTemplate);
+  Config({
+    String diffTemplate = '',
+    String tagTemplate = '',
+    String versionTemplate = '',
+    this.keepEmptyUnreleased = false,
+    this.changelogNewline = true,
+  })  : diffTemplate = Diff(diffTemplate),
+        tagTemplate = Tag(tagTemplate),
+        versionTemplate = Version(versionTemplate);
 
   final Diff diffTemplate;
   final Tag tagTemplate;
+  final Version versionTemplate;
   final bool keepEmptyUnreleased;
   final bool changelogNewline;
-  final String templateTagPrefix;
 }

--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -193,6 +193,10 @@ class Project {
   }
 
   String buildVersionForTemplate(Version version) {
-    return _config.templateTagPrefix + version.toString();
+    // Use a custom version naming convention if provided. For example, versions could start
+    // with "v" in Git tags.
+    return _config.versionTemplate.isNotEmpty
+        ? _config.versionTemplate.render(version)
+        : version.toString();
   }
 }

--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -84,10 +84,10 @@ class Project {
         if (_config.diffTemplate.isNotEmpty) {
           final releases = log.history().toList();
           if (releases.isNotEmpty) {
-            final lastVersionTag =
-                _config.tagPrefix + releases.last.version.toString();
-            log.unreleased.link =
-                _config.diffTemplate.render(lastVersionTag, 'HEAD');
+            log.unreleased.link = _config.diffTemplate.render(
+              buildVersionForTemplate(releases.last.version),
+              'HEAD',
+            );
           }
         }
       });
@@ -119,14 +119,15 @@ class Project {
       release.preamble.addAll(log.unreleased.preamble);
       release.addAll(log.unreleased.changes());
       final parent = log.preceding(release.version);
-      final taggedVersion = _config.tagPrefix + release.version.toString();
       if (parent != null && _config.diffTemplate.isNotEmpty) {
-        final parentTaggedVersion =
-            _config.tagPrefix + parent.version.toString();
-        release.link =
-            _config.diffTemplate.render(parentTaggedVersion, taggedVersion);
+        release.link = _config.diffTemplate.render(
+          buildVersionForTemplate(parent.version),
+          buildVersionForTemplate(release.version),
+        );
       } else if (_config.tagTemplate.isNotEmpty) {
-        release.link = _config.tagTemplate.render(taggedVersion);
+        release.link = _config.tagTemplate.render(
+          buildVersionForTemplate(release.version),
+        );
       }
       log.add(release);
       log.unreleased.clear();
@@ -189,5 +190,9 @@ class Project {
     await _changelog.writeAsString(
         rendered + (_config.changelogNewline ? '\n' : ''),
         flush: true);
+  }
+
+  String buildVersionForTemplate(Version version) {
+    return _config.templateTagPrefix + version.toString();
   }
 }

--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -84,8 +84,10 @@ class Project {
         if (_config.diffTemplate.isNotEmpty) {
           final releases = log.history().toList();
           if (releases.isNotEmpty) {
+            final lastVersionTag =
+                _config.tagPrefix + releases.last.version.toString();
             log.unreleased.link =
-                _config.diffTemplate.render(releases.last.version, 'HEAD');
+                _config.diffTemplate.render(lastVersionTag, 'HEAD');
           }
         }
       });
@@ -117,10 +119,14 @@ class Project {
       release.preamble.addAll(log.unreleased.preamble);
       release.addAll(log.unreleased.changes());
       final parent = log.preceding(release.version);
+      final taggedVersion = _config.tagPrefix + release.version.toString();
       if (parent != null && _config.diffTemplate.isNotEmpty) {
-        release.link = _config.diffTemplate.render(parent.version, version);
+        final parentTaggedVersion =
+            _config.tagPrefix + parent.version.toString();
+        release.link =
+            _config.diffTemplate.render(parentTaggedVersion, taggedVersion);
       } else if (_config.tagTemplate.isNotEmpty) {
-        release.link = _config.tagTemplate.render(version);
+        release.link = _config.tagTemplate.render(taggedVersion);
       }
       log.add(release);
       log.unreleased.clear();

--- a/lib/src/template/version.dart
+++ b/lib/src/template/version.dart
@@ -1,0 +1,8 @@
+import 'package:cider/src/template/template.dart';
+
+final class Version extends Template {
+  const Version(super.template);
+
+  String render(Object version) =>
+      template.replaceAll('%version%', version.toString());
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cider
-version: 0.2.9
+version: 0.2.10
 description: Automatically increments, sets, prints the package version in pubspec.yaml. Adds, lists, prints entries in the changelog. Creates diff links in the changelog.
 homepage: https://github.com/f3ath/cider
 repository: https://github.com/f3ath/cider

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -292,10 +292,11 @@ I love my dog.
     });
   });
 
-  test('Tag prefix', () async {
-    // Use a config that defined a tag prefix
-    // URLs should include the prefix
-    await setupTempDir(projectRoot: 'test/template_with_tag_prefix');
+  test('Version template', () async {
+    // Use a config that defined a version template
+    // URLs should be modified accordingly
+    // This template prepends "v" to the version numbers
+    await setupTempDir(projectRoot: 'test/template_with_custom_version');
 
     final code = await run(['log', 'a', 'Initial release']); // prefix must work
     expect(code, 0);

--- a/test/template_with_custom_version/pubspec.yaml
+++ b/test/template_with_custom_version/pubspec.yaml
@@ -6,4 +6,4 @@ cider:
   link_template:
     diff: https://github.com/example/project/compare/%from%...%to%
     tag: https://github.com/example/project/releases/tag/%tag%
-    tag_prefix: v
+    version: v%version%

--- a/test/template_with_tag_prefix/pubspec.yaml
+++ b/test/template_with_tag_prefix/pubspec.yaml
@@ -1,0 +1,9 @@
+name: test
+version: 1.1.0
+description: Test project
+
+cider:
+  tag_prefix: v
+  link_template:
+    diff: https://github.com/example/project/compare/%from%...%to%
+    tag: https://github.com/example/project/releases/tag/%tag%

--- a/test/template_with_tag_prefix/pubspec.yaml
+++ b/test/template_with_tag_prefix/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.1.0
 description: Test project
 
 cider:
-  tag_prefix: v
   link_template:
     diff: https://github.com/example/project/compare/%from%...%to%
     tag: https://github.com/example/project/releases/tag/%tag%
+    tag_prefix: v


### PR DESCRIPTION
Hello!
After trying to use this package on our project, we found ourselves with a limitation when using the diff and tag template URLs.
On our Flutter app releases, we use a tag prefix to trigger CI/CD pipelines. So a git tag "v1.0.0" would actually release and a tag "1.0.0" wouldn't.
What this PR does is add an extra config option "link_template/version", which is a template for the version used in link templates (tag or diff). In this case the template could be: "v%value%"

I look forward to your thoughts on this.